### PR TITLE
Fix Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ EXPOSE 8000
 EXPOSE 80
 
 # Copy entrypoint
-COPY ./start.sh /start.sh
-RUN chmod +x /start.sh
+COPY ./app/docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
-CMD ["/start.sh"]
+CMD ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- point Dockerfile to use `app/docker-entrypoint.sh`
- ensure entrypoint script is executable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866dcb425dc832f915c93aed69600a1