### PR TITLE
Fix router tags to lower case

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -33,9 +33,9 @@ app.mount(
 app.include_router(api_router, prefix="/api/v1")
 app.include_router(users.router, prefix="/api/v1")
 app.include_router(discord.router, prefix="/api/v1")
-app.include_router(system.router, prefix="/api/v1/system", tags=["System"])
+app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(ws_status.router, prefix="/api/v1/ws", tags=["WebSocket"])
-app.include_router(admin.router, prefix="/api/v1/admin", tags=["Admin"])
+app.include_router(admin.router, prefix="/api/v1/admin", tags=["admin"])
 app.include_router(jwks.router, prefix="", tags=["JWKS"])
 
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -9,7 +9,7 @@ from app.db.database import get_db
 from app.dependencies.auth import admin_required  # ✅ Ensure proper path
 from app.services.auth_service import log_action
 
-router = APIRouter(prefix="/admin", tags=["Admin"])
+router = APIRouter(prefix="/admin", tags=["admin"])
 
 AUTHENTIK_API = os.getenv("AUTHENTIK_API_URL", "http://authentik:9000")
 AUTHENTIK_TOKEN = os.getenv("AUTHENTIK_API_TOKEN", "")

--- a/app/routes/checkout.py
+++ b/app/routes/checkout.py
@@ -11,7 +11,7 @@ from app.dependencies import get_current_user
 from app.db.database import get_db
 from app.models import User  # Optional: may remove if not querying user directly
 
-router = APIRouter(prefix="/checkout", tags=["Checkout"])
+router = APIRouter(prefix="/checkout", tags=["checkout"])
 
 # Load environment secrets
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY")

--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -20,7 +20,7 @@ from app.utils.system_info import get_uptime, START_TIME
 from app.schemas.system import SystemStatus
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/system", tags=["System"])
+router = APIRouter(prefix="/system", tags=["system"])
 
 boot_messages = [
     "🧠 MakerWorks Backend online — thinking in polygons.",


### PR DESCRIPTION
## Summary
- set router tags to lowercase for system, admin, and checkout routes
- include these routers in `app.main` using lowercase tags

## Testing
- `pip install fastapi` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6867b5cee420832f9037659f25506287