### PR TITLE
Update .env example paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ MODEL_DIR=/data/uploads/models
 UPLOAD_DIR=/data/uploads
 
 # Redis
-REDIS_URL=redis://192.168.1.170:6379/1
+REDIS_URL=redis://redis:6379/1
 
 # Database URLs
 DATABASE_URL=postgresql://jellystat:jellystat@db:5432/makerworks2


### PR DESCRIPTION
## Summary
- update Redis host in `.env.example`
- ensure newline at end of `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867b8ddbfd0832f9b74a278452a2b09

## Summary by Sourcery

Update the .env example to use the correct Redis host and ensure the file ends with a newline

Enhancements:
- Update Redis host in .env.example
- Add missing newline at end of .env.example