### PR TITLE
Make Celery redis url configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Copy this file to `/boot/config/plugins/dockerMan/templates-user/` on your serve
 add a new container through the Unraid web UI.
 
 Make sure the default port `8000` is published and map `/data/uploads` to a
-persistent directory on your array.  Set the required environment variables
-(for example `POSTGRES_USER`, `POSTGRES_PASSWORD`, `REDIS_URL`, and
-`JWT_SECRET_KEY`) to match your setup.
+persistent directory on your array. Set the required environment variables
+(for example `POSTGRES_USER`, `POSTGRES_PASSWORD`, `REDIS_URL`,
+`CELERY_REDIS_URL`, and `JWT_SECRET_KEY`) to match your setup. `CELERY_REDIS_URL`
+defaults to `redis://redis:6379/0` if unset and controls the Celery broker and
+result backend.
 
 ## Project Layout
 ```

--- a/app/celery_worker.py
+++ b/app/celery_worker.py
@@ -1,12 +1,17 @@
 # celery_worker.py — MakerWorks task runner
 
+import os
+
 from celery import Celery
 
 # ─────────────────────────────────────────────────────────────
 # Redis: default local Redis on db 0
 # ─────────────────────────────────────────────────────────────
 
-CELERY_REDIS_URL = "redis://localhost:6379/0"
+# Connection URL for Celery's broker and result backend.
+# Defaults to the docker-compose Redis instance but can be overridden via the
+# CELERY_REDIS_URL environment variable.
+CELERY_REDIS_URL = os.environ.get("CELERY_REDIS_URL", "redis://redis:6379/0")
 
 # ─────────────────────────────────────────────────────────────
 # Celery App


### PR DESCRIPTION
## Summary
- make Celery use `CELERY_REDIS_URL` environment variable with default `redis://redis:6379/0`
- document the new env var in README

## Testing
- `ruff check app/celery_worker.py --no-fix`
- `black --check app/celery_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_6867bbebc784832f8ea9509ddbadc248