### PR TITLE
Fix admin upload query

### DIFF
--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -14,5 +14,5 @@ class Favorite(Base):
     model_id = Column(UUID(as_uuid=True), ForeignKey("models.id"), primary_key=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
-    user = relationship("User", backref="favorites", lazy="joined")
+    user = relationship("User", back_populates="favorites", lazy="joined")
     model = relationship("Model3D", backref="favorited_by", lazy="joined")

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -4,7 +4,7 @@ from sqlalchemy.future import select
 import httpx
 import os
 
-from app.models import ModelMetadata
+from app.models import ModelMetadata, Model3D
 from app.db.database import get_db
 from app.dependencies.auth import admin_required  # ✅ Ensure proper path
 from app.services.auth_service import log_action
@@ -97,7 +97,9 @@ async def view_user_uploads(
     admin=Depends(admin_required)
 ):
     result = await db.execute(
-        select(ModelMetadata).where(ModelMetadata.user_id == user_id)
+        select(ModelMetadata)
+        .join(Model3D, ModelMetadata.model_id == Model3D.id)
+        .where(Model3D.uploader_id == user_id)
     )
     return result.scalars().all()
 

--- a/tests/test_admin_view_user_uploads.py
+++ b/tests/test_admin_view_user_uploads.py
@@ -1,0 +1,73 @@
+import sys
+import os
+import uuid
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# ensure required env vars for settings so importing routes doesn't fail
+defaults = {
+    "ENV": "test",
+    "DOMAIN": "http://localhost",
+    "BASE_URL": "http://localhost",
+    "VITE_API_BASE_URL": "http://localhost",
+    "UPLOAD_DIR": "/tmp",
+    "MODEL_DIR": "/tmp",
+    "AVATAR_DIR": "/tmp",
+    "DATABASE_URL": "sqlite:///./test.db",
+    "ASYNC_DATABASE_URL": "sqlite+aiosqlite:///:memory:",
+    "REDIS_URL": "redis://localhost:6379/1",
+    "AUTHENTIK_URL": "http://authentik",
+    "AUTHENTIK_CLIENT_ID": "id",
+    "AUTHENTIK_CLIENT_SECRET": "secret",
+    "STRIPE_SECRET_KEY": "sk",
+    "STRIPE_WEBHOOK_SECRET": "wh",
+    "METRICS_API_KEY": "metrics",
+}
+
+for k, v in defaults.items():
+    os.environ.setdefault(k, v)
+
+from app.db import Base
+from app.models import User, Model3D, ModelMetadata
+from app.routes.admin import view_user_uploads
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_view_user_uploads_filters_by_uploader(db_session: AsyncSession):
+    user_uuid = uuid.uuid4()
+    other_uuid = uuid.uuid4()
+
+    user_id = str(user_uuid)
+    other_user_id = str(other_uuid)
+
+    db_session.add_all([
+        User(id=user_id, email="a@example.com", username="usera"),
+        User(id=other_user_id, email="b@example.com", username="userb"),
+    ])
+    await db_session.commit()
+
+    model_1 = Model3D(id=uuid.uuid4(), name="m1", uploader_id=user_uuid)
+    model_2 = Model3D(id=uuid.uuid4(), name="m2", uploader_id=other_uuid)
+    db_session.add_all([model_1, model_2])
+    await db_session.commit()
+
+    meta_1 = ModelMetadata(model_id=model_1.id, volume_mm3=1.0, dimensions_mm={"x":1,"y":1,"z":1}, face_count=10)
+    meta_2 = ModelMetadata(model_id=model_2.id, volume_mm3=2.0, dimensions_mm={"x":2,"y":2,"z":2}, face_count=20)
+    db_session.add_all([meta_1, meta_2])
+    await db_session.commit()
+
+    results = await view_user_uploads(user_id=user_uuid, db=db_session, admin=None)
+    assert len(results) == 1
+    assert results[0].model_id == model_1.id


### PR DESCRIPTION
## Summary
- fix `view_user_uploads` query by joining `Model3D`
- tweak `Favorite` relationship to use `back_populates`
- add regression test for admin uploads filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c0b021d8832f9e14bb752b45207d

## Summary by Sourcery

Fix the admin uploads endpoint to filter by actual uploader, update the Favorite model relationship, and add a regression test for upload filtering

Bug Fixes:
- Fix view_user_uploads query to join Model3D and filter by uploader_id instead of metadata user_id

Enhancements:
- Refactor Favorite.user relationship to use back_populates instead of backref

Tests:
- Add a regression test to ensure view_user_uploads only returns metadata for the correct uploader