### PR TITLE
Fix DB import in init scripts

### DIFF
--- a/app/init_db.py
+++ b/app/init_db.py
@@ -1,6 +1,6 @@
 # app/init_db.py
 import asyncio
-from app.database import engine
+from app.db.database import engine
 from app.models import Base
 
 async def init_models():

--- a/app/init_subset.py
+++ b/app/init_subset.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from app.database import engine
+from app.db.database import engine
 from app.models import User, Filament  # Add other tables selectively
 
 logger = logging.getLogger("makerworks.init_subset")


### PR DESCRIPTION
## Summary
- update `init_db.py` and `init_subset.py` to import `engine` from `app.db.database`

## Testing
- `python -m app.init_db`
- `python -m app.init_subset`


------
https://chatgpt.com/codex/tasks/task_e_6867c80eb08c832f8b2a0698222e78eb

## Summary by Sourcery

Bug Fixes:
- Correct engine import path in init_db.py and init_subset.py to use app.db.database