### PR TITLE
Add aiosqlite and authlib dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the FastAPI + Celery + PostgreSQL backend powering the MakerWorks 3D pri
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs dependencies such as aiosqlite and authlib
 cp .env.example .env
 alembic upgrade head
 uvicorn app.main:app --reload

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ uvicorn[standard]
 sqlalchemy>=2.0
 greenlet>=3.0
 asyncpg
+aiosqlite
 psycopg2-binary
 alembic>=1.13.1
 
@@ -13,6 +14,7 @@ alembic>=1.13.1
 python-jose[cryptography]         # JWT signing/verification
 passlib[bcrypt]                   # Password hashing
 jwcrypto>=1.4.2                   # JWKS, token crypto
+authlib
 
 # 🧠 Pydantic & Settings
 pydantic>=2.0


### PR DESCRIPTION
## Summary
- include `aiosqlite` in the database section
- include `authlib` for auth utilities
- document the new packages in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726d2a5fb8832fae3d85bb550c16ff

## Summary by Sourcery

Add asynchronous SQLite support and authentication utilities by introducing aiosqlite and authlib to the project dependencies and update the README accordingly

New Features:
- Include aiosqlite for asynchronous SQLite database access
- Include authlib for authentication utilities

Documentation:
- Document aiosqlite and authlib installation in the README