### PR TITLE
Add allowed redirect URIs config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,4 @@ AUTHENTIK_CLIENT_ID=client-id
 AUTHENTIK_CLIENT_SECRET=client-secret
 
 CORS_ORIGINS=http://localhost:5173
+ALLOWED_REDIRECT_URIS=http://localhost:5173/callback

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -118,6 +118,23 @@ class Settings(BaseSettings):
     # ────────────────
     metrics_api_key: str = Field(..., alias="METRICS_API_KEY")
 
+    # ────────────────
+    # OAuth2 Redirect URIs
+    # ────────────────
+    allowed_redirect_uris_raw: str = Field("", alias="ALLOWED_REDIRECT_URIS")
+    allowed_redirect_uris: list[str] = []
+
+    @model_validator(mode="after")
+    def parse_allowed_redirect_uris(cls, values):
+        raw = values.allowed_redirect_uris_raw
+        if raw:
+            values.allowed_redirect_uris = [
+                uri.strip() for uri in raw.split(",") if uri.strip()
+            ]
+        else:
+            values.allowed_redirect_uris = []
+        return values
+
 
 @lru_cache
 def get_settings() -> Settings:
@@ -125,5 +142,17 @@ def get_settings() -> Settings:
 
 
 settings = get_settings()
+AUTHENTIK_TOKEN_URL = f"{settings.authentik_url.rstrip('/')}/application/o/token/"
+AUTHENTIK_USERINFO_URL = f"{settings.authentik_url.rstrip('/')}/application/o/userinfo/"
+AUTHENTIK_CLIENT_ID = settings.authentik_client_id
+AUTHENTIK_CLIENT_SECRET = settings.authentik_client_secret
+ALLOWED_REDIRECT_URIS = settings.allowed_redirect_uris
 
-__all__ = ["settings"]
+__all__ = [
+    "settings",
+    "AUTHENTIK_TOKEN_URL",
+    "AUTHENTIK_USERINFO_URL",
+    "AUTHENTIK_CLIENT_ID",
+    "AUTHENTIK_CLIENT_SECRET",
+    "ALLOWED_REDIRECT_URIS",
+]


### PR DESCRIPTION
## Summary
- support multiple OAuth redirect URIs in settings
- expose Authentik URLs/constants from config
- document new ALLOWED_REDIRECT_URIS env var

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6878cecd09b8832fbc51322bebd404f9

## Summary by Sourcery

Introduce support for multiple OAuth redirect URIs by parsing a comma-separated ALLOWED_REDIRECT_URIS env var, and expose Authentik OAuth endpoints and credentials as constants for use throughout the application.

New Features:
- Allow configuring multiple OAuth redirect URIs via ALLOWED_REDIRECT_URIS environment variable
- Export Authentik OAuth token and userinfo endpoints and client credentials as module-level constants

Enhancements:
- Parse comma-separated ALLOWED_REDIRECT_URIS into a list in the settings model

Documentation:
- Document the new ALLOWED_REDIRECT_URIS environment variable in .env.example