### PR TITLE
Add IP whitelist validation for Bambu printer routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,4 @@ AUTHENTIK_CLIENT_SECRET=client-secret
 
 CORS_ORIGINS=http://localhost:5173
 ALLOWED_REDIRECT_URIS=http://localhost:5173/callback
+BAMBU_ALLOWED_HOSTS=127.0.0.1


### PR DESCRIPTION
## Summary
- secure Bambu Connect endpoints by validating provided IPs against a whitelist
- parse comma-separated allowed hosts from `BAMBU_ALLOWED_HOSTS` in settings
- document the new environment variable in `.env.example`

## Testing
- `ruff check app/routes/bambu_connect.py app/config/settings.py`
- `pytest -q` *(fails: 1 failed, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878d7640720832fbb7bd6752048669d

## Summary by Sourcery

Secure Bambu printer endpoints by adding environment-driven IP whitelist parsing in application settings and enforcing allowed hosts in relevant routes.

New Features:
- Introduce IP whitelist validation for Bambu Connect API routes

Enhancements:
- Parse comma-separated BAMBU_ALLOWED_HOSTS into a list in settings
- Default BAMBU_ALLOWED_HOSTS to localhost if unset

Documentation:
- Document the BAMBU_ALLOWED_HOSTS environment variable in .env.example