### PR TITLE
Replace authentik auth with local JWT

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -24,30 +24,31 @@ class Settings(BaseSettings):
     # ─── Redis / Celery ─────────────────────────────────────
     redis_url: str = Field("redis://localhost:6379", alias="REDIS_URL")
 
-    # ─── JWT / Authentik ────────────────────────────────────
-    jwt_algorithm: str = Field(default="RS256", alias="JWT_ALGORITHM")  # now RS256
+    # ─── JWT / Auth ─────────────────────────────────────────
+    jwt_algorithm: str = Field(default="HS256", alias="JWT_ALGORITHM")
+    jwt_secret: str = Field(default="secret", alias="JWT_SECRET")
     private_key_path: str | None = Field(default=None, alias="PRIVATE_KEY_PATH")  # optional if JWKS
     public_key_path: str | None = Field(default=None, alias="PUBLIC_KEY_PATH")    # optional if JWKS
     private_key_kid: str = Field(default="makerworks-key", alias="PRIVATE_KEY_KID")
     auth_audience: str = Field(default="makerworks", alias="AUTH_AUDIENCE")
 
     # ─── Authentik ──────────────────────────────────────────
-    authentik_url: str = Field(..., alias="AUTHENTIK_URL")
-    authentik_issuer: str = Field(..., alias="AUTHENTIK_ISSUER")
-    authentik_client_id: str = Field(..., alias="AUTHENTIK_CLIENT_ID")
-    authentik_client_secret: str = Field(..., alias="AUTHENTIK_CLIENT_SECRET")
+    authentik_url: str = Field("", alias="AUTHENTIK_URL")
+    authentik_issuer: str = Field("", alias="AUTHENTIK_ISSUER")
+    authentik_client_id: str = Field("", alias="AUTHENTIK_CLIENT_ID")
+    authentik_client_secret: str = Field("", alias="AUTHENTIK_CLIENT_SECRET")
 
     # ─── Stripe ─────────────────────────────────────────────
-    stripe_secret_key: str = Field(..., alias="STRIPE_SECRET_KEY")
-    stripe_webhook_secret: str = Field(..., alias="STRIPE_WEBHOOK_SECRET")
+    stripe_secret_key: str = Field("", alias="STRIPE_SECRET_KEY")
+    stripe_webhook_secret: str = Field("", alias="STRIPE_WEBHOOK_SECRET")
 
     # ─── Discord ────────────────────────────────────────────
-    discord_channel_id: str = Field(..., alias="DISCORD_CHANNEL_ID")
-    discord_bot_token: str = Field(..., alias="DISCORD_BOT_TOKEN")
-    discord_webhook_url: str = Field(..., alias="DISCORD_WEBHOOK_URL")
+    discord_channel_id: str = Field("", alias="DISCORD_CHANNEL_ID")
+    discord_bot_token: str = Field("", alias="DISCORD_BOT_TOKEN")
+    discord_webhook_url: str = Field("", alias="DISCORD_WEBHOOK_URL")
 
     # ─── Monitoring ─────────────────────────────────────────
-    metrics_api_key: str = Field(..., alias="METRICS_API_KEY")
+    metrics_api_key: str = Field("", alias="METRICS_API_KEY")
 
     # ─── CORS ───────────────────────────────────────────────
     raw_cors_origins: str | list[AnyHttpUrl] = Field(default="", alias="CORS_ORIGINS")

--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -1,153 +1,69 @@
-import os
-import httpx
-from fastapi import Depends, Header, HTTPException, Query, Request
+from fastapi import Depends, Header, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.db.database import get_db
 from app.models.models import User
-
-AUTHENTIK_USERINFO_URL = os.getenv(
-    "AUTHENTIK_USERINFO_URL",
-    "http://localhost:9000/application/o/userinfo/",
-)
-
-ADMIN_EMAILS = os.getenv("ADMIN_EMAILS", "").split(",")
-
-
-def parse_groups(groups_raw: str) -> list[str]:
-    return [g.strip() for g in groups_raw.split(",") if g.strip()]
+from app.schemas.token import TokenData
+from app.services.token_service import decode_token
 
 
 async def get_current_user(
-    request: Request,
-    x_authentik_email: str = Header(None, alias="X-Authentik-Email"),
-    x_authentik_username: str = Header(None, alias="X-Authentik-Username"),
-    x_authentik_groups: str = Header("", alias="X-Authentik-Groups"),
+    authorization: str = Header(...),
     db: AsyncSession = Depends(get_db),
 ) -> User:
-    """
-    Resolve the current user from either X-Authentik headers
-    (preferred when behind Outpost) or by calling Authentik /userinfo/ endpoint
-    with provided Bearer token.
-    """
-    email = x_authentik_email
-    username = x_authentik_username
-    groups_raw = x_authentik_groups
-
-    if not email:
-        token = request.headers.get("Authorization")
-        if not token or not token.startswith("Bearer "):
-            raise HTTPException(
-                status_code=401, detail="Missing authentication headers or token."
-            )
-        token = token.split("Bearer ")[1]
-
-        # Always query Authentik /userinfo/
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(
-                    AUTHENTIK_USERINFO_URL,
-                    headers={"Authorization": f"Bearer {token}"},
-                )
-                response.raise_for_status()
-                data = response.json()
-                email = data.get("email")
-                username = data.get("username") or data.get("preferred_username") or email
-                groups_raw = ",".join(data.get("groups", []))
-            except Exception as e:
-                raise HTTPException(
-                    status_code=401, detail="Invalid Authentik token."
-                ) from e
-
-    groups = parse_groups(groups_raw)
-
-    # Get or create local DB record
-    result = await db.execute(select(User).where(User.email == email))
-    user = result.scalars().first()
-
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid Authorization header")
+    token = authorization.split(" ")[1]
+    try:
+        payload = decode_token(token)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail="Invalid token") from e
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
     if not user:
-        user = User(
-            email=email,
-            username=username,
-            is_verified=True,
-            role=(
-                "admin"
-                if "MakerWorks-Admin" in groups or email in ADMIN_EMAILS
-                else "user"
-            ),
-        )
-        db.add(user)
-        await db.commit()
-        await db.refresh(user)
-    else:
-        # Sync role with Authentik groups
-        if "MakerWorks-Admin" in groups or email in ADMIN_EMAILS:
-            user.role = "admin"
-        elif "MakerWorks-User" in groups:
-            user.role = "user"
-        else:
-            user.role = "guest"
-
+        raise HTTPException(status_code=401, detail="User not found")
     return user
 
 
-async def get_user_from_headers(authorization: str = Header(...)) -> dict:
-    """
-    Fetch userinfo directly from Authentik using Authorization header.
-    """
+async def get_user_from_headers(authorization: str = Header(...)) -> TokenData:
     if not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=401, detail="Invalid Authorization header format."
-        )
-
-    token = authorization.split("Bearer ")[1]
-
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                AUTHENTIK_USERINFO_URL, headers={"Authorization": f"Bearer {token}"}
-            )
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            raise HTTPException(
-                status_code=401, detail="Invalid or expired token."
-            ) from e
+        raise HTTPException(status_code=401, detail="Invalid Authorization header")
+    token = authorization.split(" ")[1]
+    try:
+        payload = decode_token(token)
+        return TokenData(**payload)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail="Invalid token") from e
 
 
-async def get_user_from_token_query(token: str = Query(...)) -> dict:
-    """
-    Authenticate user from WebSocket query param: ?token=xxx
-    """
-    if not token.startswith("Bearer "):
-        token = f"Bearer {token}"
-
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                AUTHENTIK_USERINFO_URL, headers={"Authorization": token}
-            )
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            raise HTTPException(
-                status_code=401, detail="Invalid or missing token in query"
-            ) from e
+async def get_user_from_token_query(token: str) -> TokenData:
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing token")
+    if token.startswith("Bearer "):
+        token = token.split(" ")[1]
+    try:
+        payload = decode_token(token)
+        return TokenData(**payload)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail="Invalid token") from e
 
 
 async def get_current_admin_user(user: User = Depends(get_current_user)) -> User:
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="Admin access required.")
+        raise HTTPException(status_code=403, detail="Admin access required")
     return user
 
 
 def admin_required(user: User = Depends(get_current_user)) -> User:
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="Admin privileges required.")
+        raise HTTPException(status_code=403, detail="Admin privileges required")
     return user
 
 
 async def assert_user_is_admin(user: User = Depends(get_current_user)) -> None:
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="Admin access required.")
+        raise HTTPException(status_code=403, detail="Admin access required")

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -171,3 +171,25 @@ class AuditLog(Base):
 
     def __repr__(self):
         return f"<AuditLog id={self.id} user_id={self.user_id} action={self.action}>"
+
+
+class FilamentPricing(Base):
+    __tablename__ = "filament_pricing"
+
+    id = Column(String, primary_key=True)
+    filament_id = Column(UUID(as_uuid=True), ForeignKey("filaments.id"), nullable=False)
+    price_per_gram = Column(Float, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    filament = relationship("Filament")
+
+
+class EstimateSettings(Base):
+    __tablename__ = "estimate_settings"
+
+    id = Column(String, primary_key=True)
+    custom_text_base_cost = Column(Float, default=2.0)
+    custom_text_cost_per_char = Column(Float, default=0.1)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,132 +1,32 @@
-# app/services/token_service.py
-
-import json
-import logging
+import os
 import uuid
 from datetime import datetime, timedelta
 
-import httpx
-from authlib.jose import JsonWebKey, jwt as authlib_jwt
-from fastapi import HTTPException, status
-from jose import jwt
+from jose import jwt, JWTError
 
 from app.config.settings import settings
-from app.services.redis_service import get_redis
 
-logger = logging.getLogger(__name__)
-
-JWKS_CACHE_KEY = "jwks:authentik"
-JWKS_TTL_SECONDS = int(timedelta(hours=6).total_seconds())  # 6 hours
+JWT_SECRET = settings.jwt_secret
+JWT_ALGORITHM = settings.jwt_algorithm
 
 
-# ──────────────────────────────────────────────────────────────
-# Load RS256 Private Key for Signing
-# ──────────────────────────────────────────────────────────────
-
-
-def load_private_key() -> str:
-    try:
-        with open(settings.private_key_path) as f:
-            return f.read()
-    except Exception as e:
-        raise RuntimeError(
-            f"Could not load private key from {settings.private_key_path}: {e}"
-        ) from e
-
-
-# ──────────────────────────────────────────────────────────────
-# Create RS256 Access Token
-# ──────────────────────────────────────────────────────────────
-
-
-def create_access_token(
-    user_id: str,
-    email: str,
-    role: str = "user",
-    expires_delta: timedelta = timedelta(hours=2),
-) -> str:
+def create_access_token(user_id: str, email: str, role: str = "user", expires_delta: timedelta = timedelta(hours=2)) -> str:
     now = datetime.utcnow()
     expire = now + expires_delta
     jti = str(uuid.uuid4())
-
     payload = {
-        "sub": str(user_id),  # ensure UUID is string
+        "sub": str(user_id),
         "email": email,
         "role": role,
         "jti": jti,
         "iat": int(now.timestamp()),
         "exp": int(expire.timestamp()),
-        "aud": settings.auth_audience,
-        "iss": settings.domain,
     }
-
-    private_key = load_private_key()
-    return jwt.encode(
-        payload,
-        private_key,
-        algorithm="RS256",
-        headers={"kid": settings.private_key_kid},
-    )
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
-# ──────────────────────────────────────────────────────────────
-# Get JWKS from Redis or Fetch from Authentik
-# ──────────────────────────────────────────────────────────────
-
-
-async def get_jwks() -> JsonWebKey:
-    redis = await get_redis()
-
+def decode_token(token: str) -> dict:
     try:
-        cached = await redis.get(JWKS_CACHE_KEY)
-        if cached:
-            logger.debug("[JWKS] Loaded JWKS from Redis cache")
-            return JsonWebKey.import_key_set(json.loads(cached))
-    except Exception as e:
-        logger.warning(f"[JWKS] Redis fetch failed: {e}")
-
-    try:
-        jwks_url = f"{settings.authentik_issuer.rstrip('/')}/.well-known/jwks.json"
-        async with httpx.AsyncClient() as client:
-            res = await client.get(jwks_url, timeout=10)
-            res.raise_for_status()
-            jwks_json = res.json()
-
-        try:
-            await redis.set(JWKS_CACHE_KEY, json.dumps(jwks_json), ex=JWKS_TTL_SECONDS)
-            logger.debug("[JWKS] Cached JWKS in Redis")
-        except Exception as e:
-            logger.warning(f"[JWKS] Redis set failed: {e}")
-
-        return JsonWebKey.import_key_set(jwks_json)
-
-    except Exception as e:
-        raise RuntimeError(f"Failed to fetch JWKS from Authentik: {e}") from e
-
-
-# ──────────────────────────────────────────────────────────────
-# Validate RS256 Token from Authentik
-# ──────────────────────────────────────────────────────────────
-
-
-async def verify_token_rs256(token: str) -> dict:
-    try:
-        jwks = await get_jwks()
-        claims = authlib_jwt.decode(
-            token,
-            key=jwks,
-            claims_options={
-                "iss": {"value": settings.authentik_issuer},
-                "aud": {"value": settings.auth_audience},
-                "exp": {"essential": True},
-                "sub": {"essential": True},
-            },
-        )
-        claims.validate()
-        return claims
-    except Exception as e:
-        logger.warning(f"[JWT] Verification failed: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Invalid JWT: {e}",
-        ) from e
+        return jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except JWTError as e:
+        raise ValueError(f"Invalid token: {e}") from e

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -1,23 +1,39 @@
-# app/utils/security.py
+from datetime import datetime, timedelta
+import os
 
-"""
-This module is kept for compatibility but is no longer used.
+from jose import jwt, JWTError
+from passlib.context import CryptContext
 
-⚠️ Authentik now handles:
-- Password hashing & verification
-- JWT creation & signing (RS256)
+# Password hashing context
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-If local JWT creation or password hashing is ever needed again,
-you can restore the original implementation.
-"""
+# JWT configuration
+JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 
-# No-op stub — Authentik handles authentication & tokens.
 
-def create_access_token(*args, **kwargs):
-    raise NotImplementedError("JWTs are now issued by Authentik.")
+def hash_password(password: str) -> str:
+    """Hash a plaintext password using bcrypt."""
+    return pwd_context.hash(password)
 
-def hash_password(*args, **kwargs):
-    raise NotImplementedError("Passwords are handled by Authentik.")
 
-def verify_password(*args, **kwargs):
-    raise NotImplementedError("Passwords are handled by Authentik.")
+def verify_password(password: str, hashed: str) -> bool:
+    """Verify a plaintext password against a hash."""
+    return pwd_context.verify(password, hashed)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    """Create a signed JWT access token."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(hours=1))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def decode_token(token: str) -> dict:
+    """Decode a JWT token and return its payload."""
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        return payload
+    except JWTError as e:
+        raise ValueError(f"Invalid token: {e}") from e


### PR DESCRIPTION
## Summary
- implement simple HS256 JWT handling
- add sign-up, sign-in, and sign-out routes
- provide basic auth dependencies
- simplify auth service for local token verification
- define missing models for estimates
- make settings provide defaults so env vars aren't required

## Testing
- `pytest -q` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5ff7480c832f811d6e3f1e83c0b2

## Summary by Sourcery

Replace Authentik integration with local HS256 JWT authentication, providing sign-up, sign-in, sign-out, and session introspection endpoints, simplify authentication dependencies, default configuration settings, and add missing estimate-related database models.

New Features:
- Introduce local JWT creation and decoding service using HS256.
- Add sign-up, sign-in, sign-out, and /me endpoints for user authentication.
- Implement password hashing and verification utilities.
- Provide a debug route for token inspection.

Enhancements:
- Remove external Authentik OAuth2 and userinfo calls, replacing with local token-based user resolution.
- Simplify settings to supply default environment variable values.
- Streamline authentication dependencies and services to use local JWT payloads.

Chores:
- Define new database models FilamentPricing and EstimateSettings for estimates.