### PR TITLE
Fix AuditLog entry fields

### DIFF
--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -82,10 +82,10 @@ async def log_action(admin_id: str, action: str, target_user_id: str, db: AsyncS
         target_user_id,
     )
     entry = AuditLog(
-        admin_id=admin_id,
+        user_id=admin_id,
         action=action,
-        target_user_id=target_user_id,
-        timestamp=datetime.utcnow(),
+        target=target_user_id,
+        created_at=datetime.utcnow(),
     )
     db.add(entry)
     await db.commit()


### PR DESCRIPTION
## Summary
- use correct AuditLog field names

## Testing
- `pytest -q` *(fails: OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_687b82e8a488832fa2159f3c31c6b820

## Summary by Sourcery

Fix AuditLog model field names when creating log entries

Bug Fixes:
- Rename admin_id to user_id in AuditLog constructor
- Rename target_user_id to target in AuditLog constructor
- Rename timestamp to created_at in AuditLog constructor