### PR TITLE
Fix filament color column name

### DIFF
--- a/update_filament_colors.sql
+++ b/update_filament_colors.sql
@@ -1,23 +1,23 @@
--- 🎨 Assign proper hex codes to filaments based on color_name
+-- 🎨 Assign proper color_hex codes to filaments based on color_name
 
-UPDATE filaments SET hex = '#000000' WHERE LOWER(color_name) = 'black';
-UPDATE filaments SET hex = '#FF0000' WHERE LOWER(color_name) = 'red';
-UPDATE filaments SET hex = '#0000FF' WHERE LOWER(color_name) = 'blue';
-UPDATE filaments SET hex = '#00FF00' WHERE LOWER(color_name) = 'green';
-UPDATE filaments SET hex = '#FFFF00' WHERE LOWER(color_name) = 'yellow';
-UPDATE filaments SET hex = '#FFFFFF' WHERE LOWER(color_name) = 'white';
-UPDATE filaments SET hex = '#808080' WHERE LOWER(color_name) = 'gray';
-UPDATE filaments SET hex = '#00008B' WHERE LOWER(color_name) = 'dark blue';
-UPDATE filaments SET hex = '#006400' WHERE LOWER(color_name) = 'dark green';
-UPDATE filaments SET hex = '#8B0000' WHERE LOWER(color_name) = 'dark red';
-UPDATE filaments SET hex = '#FF8C00' WHERE LOWER(color_name) = 'dark orange';
-UPDATE filaments SET hex = '#CCCC00' WHERE LOWER(color_name) = 'dark yellow';
-UPDATE filaments SET hex = '#654321' WHERE LOWER(color_name) = 'dark brown';
-UPDATE filaments SET hex = '#1C1C1C' WHERE LOWER(color_name) = 'carbon black';
-UPDATE filaments SET hex = '#F5F5F5' WHERE LOWER(color_name) = 'clear';
+UPDATE filaments SET color_hex = '#000000' WHERE LOWER(color_name) = 'black';
+UPDATE filaments SET color_hex = '#FF0000' WHERE LOWER(color_name) = 'red';
+UPDATE filaments SET color_hex = '#0000FF' WHERE LOWER(color_name) = 'blue';
+UPDATE filaments SET color_hex = '#00FF00' WHERE LOWER(color_name) = 'green';
+UPDATE filaments SET color_hex = '#FFFF00' WHERE LOWER(color_name) = 'yellow';
+UPDATE filaments SET color_hex = '#FFFFFF' WHERE LOWER(color_name) = 'white';
+UPDATE filaments SET color_hex = '#808080' WHERE LOWER(color_name) = 'gray';
+UPDATE filaments SET color_hex = '#00008B' WHERE LOWER(color_name) = 'dark blue';
+UPDATE filaments SET color_hex = '#006400' WHERE LOWER(color_name) = 'dark green';
+UPDATE filaments SET color_hex = '#8B0000' WHERE LOWER(color_name) = 'dark red';
+UPDATE filaments SET color_hex = '#FF8C00' WHERE LOWER(color_name) = 'dark orange';
+UPDATE filaments SET color_hex = '#CCCC00' WHERE LOWER(color_name) = 'dark yellow';
+UPDATE filaments SET color_hex = '#654321' WHERE LOWER(color_name) = 'dark brown';
+UPDATE filaments SET color_hex = '#1C1C1C' WHERE LOWER(color_name) = 'carbon black';
+UPDATE filaments SET color_hex = '#F5F5F5' WHERE LOWER(color_name) = 'clear';
 
 -- optionally set unknowns to a neutral gray
 UPDATE filaments
-SET hex = '#CCCCCC'
-WHERE hex IS NULL OR hex = ''
+SET color_hex = '#CCCCCC'
+WHERE color_hex IS NULL OR color_hex = ''
   AND color_name IS NOT NULL;


### PR DESCRIPTION
## Summary
- normalize SQL update script to use `color_hex`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_687b926082a8832f80d100f9cea8c7c9

## Summary by Sourcery

Normalize update_filament_colors.sql to use the color_hex column instead of hex

Enhancements:
- Update header comment to reference color_hex codes
- Replace all UPDATE statements and the neutral gray fallback to use color_hex instead of hex