### PR TITLE
Align AuditLog creation with model

### DIFF
--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -74,17 +74,17 @@ async def get_current_user(
 # ────────────────────────────────────────────────────────────────────────────────
 
 
-async def log_action(admin_id: str, action: str, target_user_id: str, db: AsyncSession):
+async def log_action(admin_id: str, action: str, target: str, db: AsyncSession):
     logger.info(
         "[log_action] Admin %s performed '%s' on user %s",
         admin_id,
         action,
-        target_user_id,
+        target,
     )
     entry = AuditLog(
         user_id=admin_id,
         action=action,
-        target=target_user_id,
+        target=target,
         created_at=datetime.utcnow(),
     )
     db.add(entry)


### PR DESCRIPTION
## Summary
- adjust `log_action` to use `target` parameter

## Testing
- `pytest -q` *(fails: OperationalError no such table and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687b97e790d0832fb13cac9e32343e8a

## Summary by Sourcery

Align AuditLog creation with model by renaming log_action parameter and using the correct target field

Enhancements:
- Rename log_action parameter from target_user_id to target
- Update AuditLog creation and logging to use the new target parameter