### PR TITLE
Move route table print to startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,9 @@ async def lifespan(app: FastAPI):
     for key, value in snapshot.items():
         logger.info(gray(f"   {key}: {value}"))
 
+    # Print route table on startup
+    print_route_table()
+
     yield
 
     # On shutdown (optional cleanup here)
@@ -115,5 +118,3 @@ def print_route_table():
             path = route.path
             print(f"{green(methods):<10} {cyan(path)}")
 
-
-print_route_table()


### PR DESCRIPTION
## Summary
- print the registered route table during FastAPI startup instead of at import

## Testing
- `pytest -q` *(fails: OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_687b9e3260d0832f9812ed68a63e5e31

## Summary by Sourcery

Enhancements:
- Print the registered route table during the FastAPI lifespan startup hook instead of at import time