### PR TITLE
Update README for environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ This is the FastAPI + Celery + PostgreSQL backend powering the MakerWorks 3D pri
 - 📁 PostgreSQL via SQLAlchemy
 - 🖼️ Avatar uploads via `/api/v1/users/avatar`
 
+The repository ships with a `.env.example` file containing all the
+environment variables required to run the application. Copy it to `.env`
+and update the values for your environment.
+
 ## Dev Setup
 
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt  # installs dependencies such as aiosqlite and authlib
+poetry install  # installs dependencies defined in pyproject.toml
+# alternatively, use `pip install -r requirements.txt`
 cp .env.example .env
 # edit .env and update the connection strings and secrets as needed
 # `.env.example` lists all required environment variables


### PR DESCRIPTION
## Summary
- clarify dependency installation with Poetry
- document `.env.example` configuration template

## Testing
- `pytest -q` *(fails: OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_687ba101dc04832fb14293288276ebf9