### PR TITLE
Align profile update auth with other uploads

### DIFF
--- a/app/routes/upload.py
+++ b/app/routes/upload.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.settings import settings
 from app.db.database import get_db
@@ -89,7 +89,7 @@ async def upload_model(
     name: str = Form(None),
     description: str = Form(""),
     token: TokenData = Depends(get_user_from_headers),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     user_id = token.sub
 
@@ -137,8 +137,8 @@ async def upload_model(
     )
 
     db.add(model)
-    db.commit()
-    db.refresh(model)
+    await db.commit()
+    await db.refresh(model)
 
     return ModelUploadResponse(
         id=model.id,

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.db.database import get_db
-from app.dependencies.auth import get_current_user
+from app.dependencies.auth import get_current_user, get_user_from_headers
 from app.models.models import User
 from app.schemas.user import (
     UpdateUserProfile,
@@ -23,7 +23,7 @@ router = APIRouter(tags=["users"])
 @router.patch("/me", response_model=UserOut, summary="Update user profile (bio, etc.)")
 async def update_profile(
     payload: UpdateUserProfile,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_from_headers),
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -44,9 +44,9 @@ class UpdateUserProfile(BaseModel):
     Fields are optional and validated.
     """
 
-    name: str | None
-    bio: str | None
-    language: str | None  # NEW: allow updating language
+    name: str | None = None
+    bio: str | None = None
+    language: str | None = None  # NEW: allow updating language
     avatar_url: HttpUrl | None = None  # Optional frontend-provided override
 
     model_config = {"extra": "forbid"}

--- a/tests/test_update_profile.py
+++ b/tests/test_update_profile.py
@@ -1,0 +1,95 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+os.environ.setdefault("ENV", "test")
+os.environ.setdefault("DOMAIN", "http://testserver")
+os.environ.setdefault("BASE_URL", "http://testserver")
+os.environ.setdefault("VITE_API_BASE_URL", "http://testserver")
+os.environ.setdefault("UPLOAD_DIR", "/tmp")
+os.environ.setdefault("MODEL_DIR", "/tmp")
+os.environ.setdefault("AVATAR_DIR", "/tmp")
+os.environ.setdefault("ASYNC_DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET", "secret")
+
+import importlib.util
+from uuid import uuid4
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from tempfile import gettempdir
+
+from app.models.models import Base
+from app.db.database import get_db
+from app.models.models import User
+
+spec = importlib.util.spec_from_file_location(
+    "app.routes.users",
+    Path(__file__).resolve().parents[1] / "app" / "routes" / "users.py",
+)
+users = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(users)
+
+
+def create_test_app():
+    db_file = Path(gettempdir()) / "test_profile.db"
+    if db_file.exists():
+        db_file.unlink()
+    engine = create_engine(
+        f"sqlite:///{db_file}",
+        echo=False,
+        connect_args={"check_same_thread": False},
+    )
+    session_local = sessionmaker(bind=engine, class_=Session)
+
+    def override_get_db():
+        db = session_local()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def init_models():
+        User.__table__.create(engine)
+
+    app = FastAPI()
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
+
+    init_models()
+    app.state._sessionmaker = session_local
+    return app
+
+
+def add_test_user(app, user_id):
+    session_local = app.state._sessionmaker
+    with session_local() as session:
+        uid_str = str(user_id).replace("-", "")
+        user = User(
+            id=user_id,
+            email=f"{uid_str}@example.com",
+            username=uid_str,
+            hashed_password="password123",
+        )
+        session.add(user)
+        session.commit()
+
+
+@pytest.fixture()
+def client():
+    app = create_test_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def test_update_profile_requires_auth(client):
+    resp = client.patch("/api/v1/users/me", json={"bio": "hi"})
+    assert resp.status_code == 401
+
+


### PR DESCRIPTION
## Summary
- standardize auth dependency for all upload-related routes
- use async DB session in model upload route
- mark optional fields optional in `UpdateUserProfile`
- add regression test for unauthenticated profile edits

## Testing
- `pytest tests/test_update_profile.py::test_update_profile_requires_auth -q`
- `pytest -q` *(fails: OperationalError no such table: users, AttributeError: 'Tok' object has no attribute 'id', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_687d3782b738832fb66e18e767057b7b