### PR TITLE
Add thumbnail rendering for uploaded 3D models

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,4 +1,6 @@
-# app/utils/__init__.py
+"""Utility functions for MakerWorks backend."""
+
+from .render_thumbnail import generate_thumbnail
 
 # from .render_turntable import generate_turntable
 # from .render_turntable_webm import generate_turntable_webm

--- a/app/utils/render_thumbnail.py
+++ b/app/utils/render_thumbnail.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Generate a simple PNG thumbnail for a 3D model using trimesh."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import trimesh
+
+
+DEFAULT_RESOLUTION = (256, 256)
+
+
+def generate_thumbnail(model_path: Path, resolution: tuple[int, int] = DEFAULT_RESOLUTION) -> Path:
+    """Render ``model_path`` to a PNG thumbnail.
+
+    The thumbnail is saved next to the model with the same stem and a
+    ``.png`` extension.
+    """
+    thumb_path = model_path.with_suffix(".png")
+
+    try:
+        mesh = trimesh.load(model_path, force="mesh")
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load model: {exc}") from exc
+
+    if isinstance(mesh, trimesh.Scene):
+        mesh = trimesh.util.concatenate(mesh.dump())
+
+    if not isinstance(mesh, trimesh.Trimesh):
+        raise RuntimeError("Loaded file is not a triangular mesh")
+
+    scene = mesh.scene()
+    png_data = scene.save_image(resolution=resolution, visible=False)
+    if not png_data:
+        raise RuntimeError("Thumbnail generation failed")
+
+    with open(thumb_path, "wb") as f:
+        f.write(png_data)
+
+    return thumb_path
+
+
+def main(argv: list[str]):
+    if "--" not in argv:
+        print("Usage: render_thumbnail.py -- <model_path>")
+        return 1
+
+    model_path = Path(argv[argv.index("--") + 1])
+    try:
+        out_path = generate_thumbnail(model_path)
+    except Exception as exc:
+        print(f"❌ {exc}")
+        return 1
+
+    print(f"✅ thumbnail saved: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ dependencies = [
   "jwcrypto>=1.5.4",
   "pillow>=10.3.0",
   "authlib>=1.3.0",
-  "rich (>=14.0.0,<15.0.0)"
+  "rich (>=14.0.0,<15.0.0)",
+  "numpy>=2.3.1",
+  "trimesh>=4.7.1",
+  "pyglet>=2.1.6",
+  "PyOpenGL>=3.1.9",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,8 @@ urllib3==2.5.0
 uvicorn==0.35.0
 vine==5.1.0
 wcwidth==0.2.13
+
+numpy==2.3.1
+trimesh==4.7.1
+pyglet==2.1.6
+PyOpenGL==3.1.9


### PR DESCRIPTION
## Summary
- create `render_thumbnail.py` to generate PNG previews for models
- expose `generate_thumbnail` in utils
- add trimesh-based dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: OperationalError, pydantic ValidationError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687edc17d96c832f89a8caf358067921