### PR TITLE
Implement Redis-based session status tracking

### DIFF
--- a/app/dependencies/__init__.py
+++ b/app/dependencies/__init__.py
@@ -1,4 +1,9 @@
-from .auth import admin_required, get_current_admin_user, get_current_user
+from .auth import (
+    admin_required,
+    get_current_admin_user,
+    get_current_user,
+    get_user_from_token_query,
+)
 from .db import get_async_db
 
 get_current_admin = get_current_admin_user
@@ -8,5 +13,6 @@ __all__ = [
     "get_current_admin",  # Include alias
     "get_current_admin_user",
     "get_current_user",
+    "get_user_from_token_query",
     "get_async_db",
 ]

--- a/app/routes/ws_status.py
+++ b/app/routes/ws_status.py
@@ -5,6 +5,8 @@ import asyncio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
 
 from app.dependencies.auth import get_user_from_token_query
+from app.services.redis_service import get_redis
+from app.services.session_status import set_session_status
 from app.utils.system_info import get_system_status_snapshot
 from app.utils.logging import logger
 
@@ -13,6 +15,7 @@ router = APIRouter()
 
 @router.websocket("/system/status")
 async def system_status_ws(websocket: WebSocket):
+    redis = await get_redis()
     user = await get_user_from_token_query(websocket)
     if not user:
         logger.warning("🛑 WebSocket connection rejected: invalid or missing token")
@@ -21,6 +24,7 @@ async def system_status_ws(websocket: WebSocket):
 
     await websocket.accept()
     logger.info(f"📡 WebSocket connection opened for user_id={user.id}")
+    await set_session_status(redis, str(user.id), "connected")
 
     try:
         while True:
@@ -33,4 +37,5 @@ async def system_status_ws(websocket: WebSocket):
     except Exception as e:
         logger.exception(f"🔥 Unexpected WebSocket error for user_id={user.id}: {e}")
     finally:
+        await set_session_status(redis, str(user.id), "disconnected")
         logger.info(f"🧹 WebSocket cleanup complete for user_id={user.id}")

--- a/app/services/session_status.py
+++ b/app/services/session_status.py
@@ -1,0 +1,11 @@
+import time
+from redis.asyncio import Redis
+
+SESSION_PREFIX = "session:status:"
+
+async def set_session_status(redis: Redis, user_id: str, status: str, ttl: int = 3600) -> None:
+    await redis.set(f"{SESSION_PREFIX}{user_id}", status, ex=ttl)
+
+async def get_session_status(redis: Redis, user_id: str) -> str | None:
+    return await redis.get(f"{SESSION_PREFIX}{user_id}")
+


### PR DESCRIPTION
## Summary
- store websocket connection status in Redis via new `session_status` service
- check for token blacklist in `get_user_from_token_query`
- expose the new helper in dependency init
- update websocket route to record connected/disconnected events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_6880692a6d8c832fb0d296615d6e1ca2

## Summary by Sourcery

Implement Redis-backed session status tracking for websocket connections by introducing a new session_status service, updating authentication to support token blacklist checks, adding a websocket auth dependency, and recording connection events in Redis.

New Features:
- introduce session_status service to set and get user session status in Redis with TTL
- record websocket connection status as "connected" or "disconnected" in Redis
- add get_user_from_token_query dependency to authenticate websocket connections via JWT in query params

Enhancements:
- integrate token blacklist check in websocket authentication
- expose get_user_from_token_query in dependency initializer