### PR TITLE
Add redis session test

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,3 +1,4 @@
+import os
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from app.config.settings import settings
@@ -7,7 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # ─── Database Engine ────────────────────────────────
-DATABASE_URL = settings.database_url
+DATABASE_URL = os.getenv("ASYNC_DATABASE_URL", settings.database_url)
 
 engine = create_async_engine(
     DATABASE_URL,
@@ -36,4 +37,4 @@ async def get_async_db() -> AsyncSession:
 
 
 # Alias for backwards compatibility
-get_async_db = get_async_db
+get_db = get_async_db

--- a/tests/test_redis_session.py
+++ b/tests/test_redis_session.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import json
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+from app.services.redis_service import redis_client
+
+@pytest.mark.asyncio
+async def test_redis_session_store_and_retrieve():
+    await redis_client.flushdb()
+    token = "test-token"
+    user = {"id": "123", "email": "test@example.com"}
+
+    await redis_client.set(token, json.dumps(user), ex=60)
+    data = await redis_client.get(token)
+    assert data is not None
+    assert json.loads(data) == user
+    ttl = await redis_client.ttl(token)
+    assert ttl > 0


### PR DESCRIPTION
## Summary
- allow override of async database url via `ASYNC_DATABASE_URL`
- provide `get_db` alias for old imports
- add regression test verifying redis session storage

## Testing
- `pytest tests/test_redis_session.py -q`
- `pytest -q` *(fails: no fixtures and missing tables)*

------
https://chatgpt.com/codex/tasks/task_e_6881785a19b0832f88e174252964475f