### PR TITLE
Add Prometheus and Grafana support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,8 @@ STRIPE_WEBHOOK_SECRET=whsec_yourkey
 
 # 📄 Metrics
 METRICS_API_KEY=
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
 
 # 📄 CORS
 # Must be valid JSON! 👇

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the FastAPI + Celery + PostgreSQL backend powering the MakerWorks 3D pri
 - 🎯 Redis queue + Celery for background jobs
 - 📁 PostgreSQL via SQLAlchemy
 - 🖼️ Avatar uploads via `/api/v1/users/avatar`
+- 📈 Prometheus metrics & Grafana dashboards
 
 The repository ships with a `.env.example` file containing all the
 environment variables required to run the application. Copy it to `.env`
@@ -26,6 +27,16 @@ cp .env.example .env
 # `.env.example` lists all required environment variables
 alembic upgrade head
 uvicorn app.main:app --reload
+```
+
+## Monitoring
+
+Prometheus metrics are exposed at `/metrics` and secured with `METRICS_API_KEY`.
+Grafana and Prometheus services are provided via `docker-compose`. Start them
+with:
+
+```bash
+docker-compose up prometheus grafana
 ```
 
 ## License

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.routes import (
     checkout,
     filaments,
     models,
+    metrics,
     system,
     upload,
     users,
@@ -110,6 +111,7 @@ else:
     logger.warning("⚠️ STRIPE_SECRET_KEY is not set. Checkout routes not mounted.")
 
 mount(models.router, "/api/v1/models", ["models"])
+mount(metrics.router, "/metrics", ["metrics"])
 # 🔷 Discord route removed here.
 
 # ─── Mount Static Files ─────────────────────

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -19,6 +19,7 @@ from .models import router as models_router
 from .system import router as system_router
 from .upload import router as upload_router
 from .users import router as users_router
+from .metrics import router as metrics_router
 
 # Central API router
 router = APIRouter()
@@ -35,3 +36,4 @@ router.include_router(models_router, prefix="/models", tags=["models"])
 router.include_router(system_router, prefix="/system", tags=["system"])
 router.include_router(upload_router, prefix="/upload", tags=["upload"])
 router.include_router(users_router, prefix="/users", tags=["users"])
+router.include_router(metrics_router, prefix="/metrics", tags=["metrics"])

--- a/app/routes/metrics.py
+++ b/app/routes/metrics.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from app.dependencies.metrics import verify_metrics_api_key
+
+router = APIRouter()
+
+
+@router.get("", include_in_schema=False, dependencies=[Depends(verify_metrics_api_key)])
+async def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,32 @@ services:
       - BASE_URL=http://localhost:8000
     platform: linux/arm64
 
+  prometheus:
+    image: prom/prometheus
+    container_name: makerworks_prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - backend
+
+  grafana:
+    image: grafana/grafana
+    container_name: makerworks_grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
+
 volumes:
   postgres_data:
   redis_data:
+  grafana_data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'makerworks'
+    static_configs:
+      - targets: ['backend:8000']
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary
- expose Prometheus metrics via new `/metrics` route
- add monitoring services (Prometheus + Grafana) to docker-compose
- document monitoring setup in README
- include Grafana credentials in `.env.example`
- provide default Prometheus configuration

## Testing
- `pip install -r requirements.txt`
- `pip install aiosqlite`
- `pytest -q` *(fails: no such table: users, AttributeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6881fbc6f310832fb3653a685ed01bea