### PR TITLE
Add filesystem utilities constant

### DIFF
--- a/app/utils/filesystem.py
+++ b/app/utils/filesystem.py
@@ -1,3 +1,16 @@
+"""Filesystem utilities used across the project."""
+
+from pathlib import Path
+import uuid
+import logging
+
+from app.config.settings import settings
+
+UPLOADS_ROOT = settings.uploads_path
+
+logger = logging.getLogger(__name__)
+
+
 def create_user_folders(user_id: uuid.UUID) -> dict[str, bool]:
     """
     Create avatar and models folders for the given user ID.

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,23 @@
+import os
+import importlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+def test_create_user_folders(tmp_path, monkeypatch):
+    monkeypatch.setenv("UPLOADS_PATH", str(tmp_path))
+    filesystem = importlib.reload(importlib.import_module("app.utils.filesystem"))
+
+    user_id = uuid.uuid4()
+    result = filesystem.create_user_folders(user_id)
+
+    user_dir = Path(tmp_path) / str(user_id)
+    avatars = user_dir / "avatars"
+    models = user_dir / "models"
+
+    assert avatars.exists()
+    assert models.exists()
+    assert result[str(avatars)]
+    assert result[str(models)]


### PR DESCRIPTION
## Summary
- define `UPLOADS_ROOT` and module logger
- leverage `settings.uploads_path` for creating user folders
- test create_user_folders

## Testing
- `PYTHONPATH=$PWD pytest tests/test_filesystem.py::test_create_user_folders -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68827130423c832fb7fb1e9ab8ecc82c