### PR TITLE
Add thumbnail sync during authentication

### DIFF
--- a/app/db/base_class.py
+++ b/app/db/base_class.py
@@ -1,4 +1,9 @@
+import os
 from sqlalchemy import MetaData
 from sqlalchemy.orm import declarative_base
 
-Base = declarative_base(metadata=MetaData(schema="public"))
+database_url = os.getenv("DATABASE_URL", "")
+if database_url.startswith("sqlite"):
+    Base = declarative_base()
+else:
+    Base = declarative_base(metadata=MetaData(schema="public"))

--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -6,6 +6,7 @@ from app.models.models import User
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from app.services.session_backend import get_session_user_id
+from app.utils.filesystem import ensure_user_model_thumbnails
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,12 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
+
+    # After successful authentication, ensure thumbnails exist for this user's models
+    try:
+        ensure_user_model_thumbnails(str(user.id))
+    except Exception as e:
+        logger.exception("[AUTH] Thumbnail synchronization failed: %s", e)
 
     return user
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -7,7 +7,15 @@ from sqlalchemy import (
     Column, String, Boolean, DateTime, Text, Float, ForeignKey,
     UniqueConstraint, Integer
 )
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+import os
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import JSON
+
+if os.getenv("DATABASE_URL", "").startswith("sqlite"):
+    JSONType = JSON
+else:
+    from sqlalchemy.dialects.postgresql import JSONB
+    JSONType = JSONB
 from sqlalchemy.orm import relationship
 
 from app.db.base_class import Base
@@ -125,7 +133,7 @@ class ModelMetadata(Base):
     uploaded_at = Column(DateTime, default=datetime.utcnow)
 
     volume = Column(Float, nullable=True)
-    bbox = Column(JSONB, nullable=True)
+    bbox = Column(JSONType, nullable=True)
     faces = Column(Integer, nullable=True)
     vertices = Column(Integer, nullable=True)
 


### PR DESCRIPTION
## Summary
- generate thumbnails for missing model previews
- trigger thumbnail sync during user authentication
- allow tests by disabling Postgres-specific schema and JSONB when using SQLite

## Testing
- `pytest -q` *(fails: assertion and operational errors)*

------
https://chatgpt.com/codex/tasks/task_e_68857126e154832f922b295e960b6a24